### PR TITLE
fixes the pep8 warnings

### DIFF
--- a/pigar/reqs.py
+++ b/pigar/reqs.py
@@ -101,12 +101,12 @@ class ImportChecker(object):
         """
         if hasattr(node.body, 's'):
             self._str_codes.append(
-                    (getattr(node.body, 's'), node.lineno + self._lineno))
+                (getattr(node.body, 's'), node.lineno + self._lineno))
         # Sometimes exec statement may be called with tuple in py2
         elif hasattr(node.body, 'elts') and len(node.body.elts) >= 1:
             self._str_codes.append(
-                    (getattr(node.body.elts[0], 's'),
-                     node.lineno + self._lineno))
+                (getattr(node.body.elts[0], 's'),
+                    node.lineno + self._lineno))
 
     def visit_Expr(self, node):
         """

--- a/pigar/tests/imports_example/example1.py
+++ b/pigar/tests/imports_example/example1.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import os, os.path
+import os
+import os.path
 import sys
 import collections
 
@@ -13,28 +14,29 @@ eval('import foo')
 exec("import bar", {}, {})
 exec("import foobaz")
 
+
 def foo():
-	import json
-	pass
+    import json
+    pass
 
 
 class A(object):
-	"""
-	>>> import itertools
-	"""
-	pass
+    """
+    >>> import itertools
+    """
+    pass
 
-	def baz(self):
-		"""
-		>>> import baz
-		"""
+    def baz(self):
+        """
+        >>> import baz
+        """
 
 
 def bar():
-	"""
-	>>> import Queue
-	>>> def test():
-	...     import bisect
-	...     pass
-	"""
-	pass
+    """
+    >>> import Queue
+    >>> def test():
+    ...     import bisect
+    ...     pass
+    """
+    pass

--- a/pigar/tests/imports_example/example2.py
+++ b/pigar/tests/imports_example/example2.py
@@ -1,12 +1,12 @@
- # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 try:
-	import urlparse as parse  # Py2
+    import urlparse as parse  # Py2
 except ImportError:
-	from urllib import parse  # Py3
+    from urllib import parse  # Py3
 try:
-	import __builtin__ as builtins  # Py2
+    import __builtin__ as builtins  # Py2
 except ImportError:
-	import builtins  # Py3
+    import builtins  # Py3
 
 import example1

--- a/pigar/tests/test_db.py
+++ b/pigar/tests/test_db.py
@@ -25,6 +25,7 @@ class DbTests(unittest.TestCase):
         self.assertEqual(row.id, 1)
         self.assertGreaterEqual(self._conn.insert_name('pigar', row.id), 1)
         row = self._conn.query_all('pigar')
-        self.assertDictEqual(dict(row[0]), {'name': 'pigar', 'package': 'pigar'})
+        self.assertDictEqual(dict(row[0]),
+                             {'name': 'pigar', 'package': 'pigar'})
         rows = self._conn.query_package(None)
         self.assertListEqual(rows, ['pigar'])


### PR DESCRIPTION
This fixes most of the warnings generated while running pep8 test, except this
`
/pypi.py:194:80: E501 line too long (80 > 79 characters)
`
I think here the workaround can be
`
    'User-Agent':
        ('Mozilla/5.0 (X11; Linux x86_64; rv:13.0) AppleWebKit/537.36'
         ' (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36'),
`

Let me know if this is right or not?