### PR TITLE
Fix ignore dir feature

### DIFF
--- a/pigar/cmd.py
+++ b/pigar/cmd.py
@@ -94,8 +94,7 @@ def log_level_check(level):
 
 
 def ignore_dirs_check(d):
-    cur_dir = os.getcwd()
-    ignore = os.path.join(cur_dir, d[:-1] if d.endswith('/') else d)
+    ignore = os.path.abspath(d)
     if not os.path.isdir(ignore):
         raise argparse.ArgumentTypeError('"{0}" is not directory.'.format(d))
     return ignore

--- a/pigar/reqs.py
+++ b/pigar/reqs.py
@@ -36,8 +36,8 @@ def project_import_modules(project_path, ignores):
     logger.info('Extracting project: {0}'.format(project_path))
     for dirpath, dirnames, files in os.walk(project_path, followlinks=True):
         if dirpath in ignore_paths:
-            dirnames[:] = [d for d in dirnames \
-                    if d not in ignore_paths[dirpath]]
+            dirnames[:] = [d for d in dirnames
+                           if d not in ignore_paths[dirpath]]
         logger.info('Extracting directory: {0}'.format(dirpath))
         py_files = list()
         for fn in files:

--- a/pigar/reqs.py
+++ b/pigar/reqs.py
@@ -25,13 +25,19 @@ def project_import_modules(project_path, ignores):
     modules = ImportedModules()
     local_mods = list()
     cur_dir = os.getcwd()
+    ignore_paths = collections.defaultdict(set)
     if not ignores:
-        ignores = [os.path.join(project_path, d) for d in ['.git']]
+        ignore_paths[project_path] = {'.git'}
+    else:
+        for path in ignores:
+            parent_dir = os.path.dirname(path)
+            ignore_paths[parent_dir].add(os.path.basename(path))
 
     logger.info('Extracting project: {0}'.format(project_path))
     for dirpath, dirnames, files in os.walk(project_path, followlinks=True):
-        if dirpath.startswith(tuple(ignores)):
-            continue
+        if dirpath in ignore_paths:
+            dirnames[:] = [d for d in dirnames \
+                    if d not in ignore_paths[dirpath]]
         logger.info('Extracting directory: {0}'.format(dirpath))
         py_files = list()
         for fn in files:

--- a/pigar/tests/test_cmd.py
+++ b/pigar/tests/test_cmd.py
@@ -50,9 +50,14 @@ class CmdTests(unittest.TestCase):
         self.assertListEqual(list(parse_args(args)), target)
 
     def test_ignores(self):
-        args = ['-i', 'pigar']
         target = self._default_args
-        target[4] = [os.path.join(os.path.join('..', CUR_DIR), args[1])]
+        target[4] = [os.path.join(os.path.join('..', CUR_DIR), 'pigar')]
+
+        args = ['-i', 'pigar']
+        self.assertListEqual(list(parse_args(args)), target)
+        args = ['-i', './pigar']
+        self.assertListEqual(list(parse_args(args)), target)
+        args = ['-i', 'pigar/']
         self.assertListEqual(list(parse_args(args)), target)
 
     def test_save_path(self):


### PR DESCRIPTION
Force user's ignore_dir input to absolute path, so that `-i ./ignore_dir` and `-i ignore_dir` are the same. And prune the search once the directory to ignore is met.