### PR TITLE
Package the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include pigar/.db.sqlite3
+include CHANGELOGS.rst
 include README.rst
+include README-PYPI.rst
 include LICENSE
 include makefile
 include pigar/tests/fake_simple_html.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include pigar/.db.sqlite3
 include README.rst
+include LICENSE
 include makefile
 include pigar/tests/fake_simple_html.txt
 include pigar/tests/fake_top_level.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_file = LICENSE
+
 [global]
 verbose=0
 


### PR DESCRIPTION
Ensure the license file is packaged in `sdist`s, `whl`s, and other package formats.