### PR TITLE
Use check path instead of current directory

### DIFF
--- a/pigar/__main__.py
+++ b/pigar/__main__.py
@@ -71,7 +71,8 @@ class Main(object):
             print(Color.BLUE('Searching file in "{0}" ...'.format(check_path)))
             for fn in os.listdir(check_path):
                 if fnmatch.fnmatch(fn, '*requirements.txt'):
-                    files.append(os.path.abspath(fn))
+                    fnpath = os.path.join(check_path, fn)
+                    files.append(os.path.abspath(fnpath))
             # If not found in directory, generate requirements.
             if not files:
                 print(Color.YELLOW('Requirements file not found, '


### PR DESCRIPTION
This fixes #63

The problem was that the check_reqs_latest_version method of Main did not add check_path to the base name of the requirements file before finding the absolute path, so all of the final paths looked like ``current-directory/file-with-requirements.txt`` instead of ``current-directory/check_path/file-with-requirements.txt``

This pull request adds check_path before finding the absolute path.