### PR TITLE
Partially fix #48, make parse_reqs read other requirements files recu…

### DIFF
--- a/pigar/utils.py
+++ b/pigar/utils.py
@@ -82,9 +82,6 @@ def print_table(rows, headers=['PACKAGE', 'CURRENT', 'LATEST']):
 
 def parse_reqs(fpath):
     """Parse requirements file."""
-    print(
-        Color.BLUE("Reading requirements from " + fpath)
-    )
     pkg_v_re = re.compile(r'^(?P<pkg>[^><==]+)[><==]{,2}(?P<version>.*)$')
     referenced_reqs_re = re.compile(r'^-r *(?P<req_f>.*)')
     reqs = dict()

--- a/pigar/utils.py
+++ b/pigar/utils.py
@@ -81,12 +81,24 @@ def print_table(rows, headers=['PACKAGE', 'CURRENT', 'LATEST']):
 
 
 def parse_reqs(fpath):
-    pkg_v_re = re.compile(r'^(?P<pkg>[^><==]+)[><==]{,2}(?P<version>.*)$')
     """Parse requirements file."""
+    pkg_v_re = re.compile(r'^(?P<pkg>[^><==]+)[><==]{,2}(?P<version>.*)$')
+    referenced_reqs_re = re.compile(r'^-r *(?P<req_f>.*)')
     reqs = dict()
     with open(fpath, 'r') as f:
         for line in f:
             if line.startswith('#'):
+                continue
+            r = referenced_reqs_re.match(line.strip())
+            if r:
+                # Parse referenced requirements file
+                additional_reqs_file = r['req_f']
+                additional_reqs_fpath = os.path.join(
+                    os.path.dirname(fpath), additional_reqs_file)
+                additional_reqs = parse_reqs(additional_reqs_fpath)
+                # Update dictionary with referenced reqs
+                for pkg, version in additional_reqs.items():
+                    reqs[pkg] = version
                 continue
             m = pkg_v_re.match(line.strip())
             if m:

--- a/pigar/utils.py
+++ b/pigar/utils.py
@@ -82,6 +82,9 @@ def print_table(rows, headers=['PACKAGE', 'CURRENT', 'LATEST']):
 
 def parse_reqs(fpath):
     """Parse requirements file."""
+    print(
+        Color.BLUE("Reading requirements from " + fpath)
+    )
     pkg_v_re = re.compile(r'^(?P<pkg>[^><==]+)[><==]{,2}(?P<version>.*)$')
     referenced_reqs_re = re.compile(r'^-r *(?P<req_f>.*)')
     reqs = dict()
@@ -94,7 +97,8 @@ def parse_reqs(fpath):
                 # Parse referenced requirements file
                 additional_reqs_file = r['req_f']
                 additional_reqs_fpath = os.path.join(
-                    os.path.dirname(fpath), additional_reqs_file)
+                    os.path.dirname(fpath), additional_reqs_file
+                )
                 additional_reqs = parse_reqs(additional_reqs_fpath)
                 # Update dictionary with referenced reqs
                 for pkg, version in additional_reqs.items():


### PR DESCRIPTION
…rsively when a line has -r.

This pull request addresses, but does not completely solve, #48. It only addresses the -r option, and not --extra-index-url, --trusted-host, etc.

In the modified version of parse_reqs, for every requirements line that looks like "-r more-requirements.txt", the function will open the named file and record its requirements as well.

I tested my code changes using the requirements files in a clone of https://github.com/be-hase/ghe-line-notify/tree/master.

Without this change, I see the following output when I run pigar -c in the root directory of that repository:
```
(envname) username@pcname:~/pigar/examples/ghe-line-notify$ pigar -c
Starting check requirements latest version ...
Searching file in "/home/username/pigar/examples/ghe-line-notify" ...
Checking requirements latest version ...
Traceback (most recent call last):
  File "/home/username/miniconda3/envs/envname/bin/pigar", line 11, in <module>
    load_entry_point('pigar', 'console_scripts', 'pigar')()
  File "/home/username/pigar/pigar/__main__.py", line 271, in main
    Main()
  File "/home/username/pigar/pigar/__main__.py", line 31, in __init__
    self.check_reqs_latest_version(
  File "/home/username/pigar/pigar/__main__.py", line 98, in check_reqs_latest_version
    latest = check_latest_version(pkg)
  File "/home/username/pigar/pigar/pypi.py", line 65, in check_latest_version
    return Downloader().download_package(package).version()
  File "/home/username/pigar/pigar/pypi.py", line 245, in download_package
    pkg_info = self.download(PKG_INFO_URL.format(name))
  File "/home/username/pigar/pigar/pypi.py", line 229, in download
    resp.raise_for_status()
  File "/home/username/miniconda3/envs/envname/lib/python3.8/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://pypi.org/pypi/-r%20requirements/common.txt/json/
```

After the change, the program correctly recognizes the additional requirements file and parses the requirements within.
```
(envname) username@pcname:~/pigar/examples/ghe-line-notify$ pigar -c
Starting check requirements latest version ...
Searching file in "/home/username/pigar/examples/ghe-line-notify" ...
Checking requirements latest version ...
Checking requirements latest version done.

 =======================================
  PACKAGE            | CURRENT | LATEST
  -------------------+---------+-------
  alembic            | 0.8.8   | 1.3.2 
  blinker            | 1.4     | 1.4   
  click              | 6.6     | 7.0   
  Flask              | 0.11.1  | 1.1.1 
  Flask-DebugToolbar | 0.10.0  | 0.10.1
  Flask-Migrate      | 2.0.0   | 2.5.2 
  Flask-Script       | 2.0.5   | 2.0.6 
  Flask-SQLAlchemy   | 2.1     | 2.4.1 
  gunicorn           | 19.6.0  | 20.0.4
  itsdangerous       | 0.24    | 1.1.0 
  Jinja2             | 2.8     | 2.10.3
  Mako               | 1.0.4   | 1.1.0 
  MarkupSafe         | 0.23    | 1.1.1 
  python-editor      | 1.0.1   | 1.0.4 
  requests           | 2.11.1  | 2.22.0
  SQLAlchemy         | 1.0.15  | 1.3.12
  Werkzeug           | 0.11.11 | 0.16.0
  psycopg2           | 2.6.2   | 2.8.4 
 =======================================
(envname) username@pcname:~/pigar/examples/ghe-line-notify$ 
```