### PR TITLE
[WIP] Support ipynb

### DIFF
--- a/pigar/reqs.py
+++ b/pigar/reqs.py
@@ -59,12 +59,20 @@ def project_import_modules(project_path, ignores):
             fake_path = fpath.split(cur_dir)[1][1:]
             logger.info('Extracting file: {0}'.format(fpath))
             with open(fpath, 'rb') as f:
-                fmodules, try_ipts = file_import_modules(fake_path, f.read())
+                if file.endswith(".py"):
+                    code = f.read()
+                if file.endswith(".ipynb"):
+                    code = get_code_from_ipynb(f.read())
+                fmodules, try_ipts = file_import_modules(fake_path, code)
                 modules |= fmodules
                 try_imports |= try_ipts
 
     logger.info('Finish extracting in project: {0}'.format(project_path))
     return modules, try_imports, local_mods
+
+
+def get_code_from_ipynb(ipynb_text):
+    pass
 
 
 def file_import_modules(fpath, fdata):

--- a/pigar/reqs.py
+++ b/pigar/reqs.py
@@ -50,6 +50,8 @@ def project_import_modules(project_path, ignores):
             if fn.endswith('.py'):
                 local_mods.append(fn[:-3])
                 py_files.append(fn)
+            if fn.endswith('.ipynb'):
+                py_files.append(fn)
         if '__init__.py' in files:
             local_mods.append(os.path.basename(dirpath))
         for file in py_files:

--- a/pigar/reqs.py
+++ b/pigar/reqs.py
@@ -77,8 +77,8 @@ def get_code_from_ipynb(ipynb_text):
     code = ""
     for cell in ipynb_dict["cells"]:
         if cell["cell_type"] == "code":
-            code += "".join(cell["source"])
-    print(code)
+            lines = cell["source"]
+            code += "".join(lines) + "\n"
     return code
 
 

--- a/pigar/reqs.py
+++ b/pigar/reqs.py
@@ -11,6 +11,7 @@ import ast
 import doctest
 import collections
 import functools
+import json
 try:
     from types import FileType  # py2
 except ImportError:
@@ -72,7 +73,13 @@ def project_import_modules(project_path, ignores):
 
 
 def get_code_from_ipynb(ipynb_text):
-    pass
+    ipynb_dict = json.loads(ipynb_text)
+    code = ""
+    for cell in ipynb_dict["cells"]:
+        if cell["cell_type"] == "code":
+            code += "".join(cell["source"])
+    print(code)
+    return code
 
 
 def file_import_modules(fpath, fdata):


### PR DESCRIPTION
This PR adds support for Jupyter notebooks. (closes issue #70)

Files ending with .ipynb are converted to normal Python code and searched for import statements, without being added to the local_imports list. I have heard that Jupyter notebooks can sometimes be imported, but this requires a lot of [finagling](https://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Importing%20Notebooks.ipynb).

I tested the code using the "demos" folder of the phageParser repository:
https://github.com/phageParser/phageParser/tree/master/demos