### PR TITLE
docs: fix simple typo, fcuntion -> function

### DIFF
--- a/pigar/helpers.py
+++ b/pigar/helpers.py
@@ -117,7 +117,7 @@ def parse_requirements(fpath):
 
 
 def cmp_to_key(cmp_func):
-    """Convert a cmp=fcuntion into a key=function."""
+    """Convert a cmp=function into a key=function."""
     class K(object):
         def __init__(self, obj, *args):
             self.obj = obj


### PR DESCRIPTION
There is a small typo in pigar/helpers.py.

Closes #91