### PR TITLE
Fixed too many values to unpack error in `parse_git_config`

### DIFF
--- a/pigar/helpers.py
+++ b/pigar/helpers.py
@@ -195,7 +195,7 @@ def parse_git_config(path):
                 section = line[1:-1].strip()
                 config[section] = dict()
             elif section:
-                key, value = line.replace(' ', '').split('=')
+                key, value = line.replace(' ', '').split('=', 1)
                 config[section][key] = value
     return config
 

--- a/pigar/tests/fake_git_conf/config
+++ b/pigar/tests/fake_git_conf/config
@@ -1,0 +1,7 @@
+[user]
+	email = pigar@example.com
+	name = Pigar
+[core]
+    editor = vim
+[credential]
+    helper = cache --timeout=3600

--- a/pigar/tests/test_helpers.py
+++ b/pigar/tests/test_helpers.py
@@ -8,7 +8,8 @@ import random
 
 from .helper import CaptureOutput
 from ..helpers import (
-    Dict, print_table, parse_requirements, compare_version, cmp_to_key
+    Dict, print_table, parse_requirements,
+    parse_git_config, compare_version, cmp_to_key
 )
 
 
@@ -69,6 +70,17 @@ class ParseReqsTest(unittest.TestCase):
         path = os.path.join(os.path.dirname(__file__), './fake_reqs.txt')
         target = {'a': '4.1.4', 'b': '2.3.0', 'c': ''}
         reqs = parse_requirements(path)
+        self.assertDictEqual(reqs, target)
+
+
+class ParseGitConfigTest(unittest.TestCase):
+    def test_parse_gitconfig(self):
+        path = os.path.join(os.path.dirname(__file__), 'fake_git_conf')
+        target = {'core': {'editor': 'vim'},
+                  'user': {'email': 'pigar@example.com', 'name': 'Pigar'},
+                  'credential': {'helper': 'cache--timeout=3600'}
+                  }
+        reqs = parse_git_config(path)
         self.assertDictEqual(reqs, target)
 
 


### PR DESCRIPTION
The helper function `parse_git_config` breaks if there is config with multiple equals operators.

The git-credentials-helper stores information using this syntax for one.

Sample gitconfig that will error on too many values to unpack as `parse_git_config` function only expects single equality operator.

```
[user]
	email = pigar@example.com
	name = Pigar
[core]
    editor = vim
[credential]
    helper = cache --timeout=3600
```

This PR adds a 1 to the split function in `parse_git_config` to make it split on first occurrence only and fixes the issue mentioned above. A simple test is also provided.