### PR TITLE
Update instructions to reflect the change to the `main` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ conda install -c conda-forge pigar
 ```
 To get the newest code from GitHub:
 ```
-pip install git+https://github.com/damnever/pigar.git@[master or other branch] --upgrade
+pip install git+https://github.com/damnever/pigar.git@[main or other branch] --upgrade
 ```
 
 ### Usage


### PR DESCRIPTION
Had to install this, but the instructions mention using `master` branch, which fails if you run:

```bash
pip install git+https://github.com/damnever/pigar.git@master --upgrade
```